### PR TITLE
Fix #44 Add displayName for configurable

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationConfigurable id="com.sburlyaev.cmd.plugin.PluginSettings"
                                  instance="com.sburlyaev.cmd.plugin.settings.PluginSettingsConfigurable"
+                                 displayName="Native Terminal Plugin"
                                  dynamic="true"/>
         <applicationService serviceImplementation="com.sburlyaev.cmd.plugin.settings.PluginSettings"/>
     </extensions>


### PR DESCRIPTION
It appears that the IntelliJ Platform now requires plugins to list their configurables' names in the plugin xml as an optimization. This is a simple fix for that issue, to prevent users from being pestered with error messages repeatedly while using the IDE.

As noted in the title, this should fix issue #44. The issue effects release version 2023.2, as well as 2023.3 beta (which was noted in the issue title).